### PR TITLE
add delete group order button and confirmation modal

### DIFF
--- a/web/src/components/ConfirmationModal.jsx
+++ b/web/src/components/ConfirmationModal.jsx
@@ -1,0 +1,29 @@
+import { chakra, ModalContent, ModalFooter, ModalOverlay, Modal, Button, ModalBody, ModalHeader } from "@chakra-ui/react";
+
+export default chakra(function ConfirmationModal({
+    className,
+    title,
+    confirmButton,
+    cancelButton,
+    isOpen,
+    onClose,
+    onConfirm
+}) {
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} className={className}>
+            <ModalOverlay />
+            <ModalContent marginTop={"30%"}>
+                <ModalHeader>{title}</ModalHeader>
+                <ModalFooter>
+                    <Button colorScheme="blue" mr={3} w="110px" onClick={onClose}>
+                        {cancelButton}
+                    </Button>
+                    <Button colorScheme="teal" w="110px" onClick={onConfirm} >
+                        {confirmButton}
+                    </Button>
+                </ModalFooter>
+            </ModalContent>
+
+        </Modal>
+    )
+})

--- a/web/src/components/ConfirmationModal.jsx
+++ b/web/src/components/ConfirmationModal.jsx
@@ -12,7 +12,7 @@ export default chakra(function ConfirmationModal({
     return (
         <Modal isOpen={isOpen} onClose={onClose} className={className}>
             <ModalOverlay />
-            <ModalContent marginTop={"30%"}>
+            <ModalContent marginTop={"20%"}>
                 <ModalHeader>{title}</ModalHeader>
                 <ModalFooter>
                     <Button colorScheme="blue" mr={3} w="110px" onClick={onClose}>

--- a/web/src/components/CreateGroupForm.jsx
+++ b/web/src/components/CreateGroupForm.jsx
@@ -67,6 +67,7 @@ export default chakra(function CreateGroupForm({ className, isOpen, onClose }) {
     } else {
       dispatch(addOrderAsync(newGroup));
       alert('Successfully Submitted Order! ' + JSON.stringify(newGroup));
+      onClose();
     }
   };
 

--- a/web/src/components/ViewOrderModal.jsx
+++ b/web/src/components/ViewOrderModal.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import { removeOrderAsync } from '../redux/orders/thunk';
 import {
   chakra,
   Box,
@@ -15,7 +17,9 @@ import {
   Text,
   Image,
   VStack,
+  useDisclosure
 } from '@chakra-ui/react';
+import ConfirmationModal from './ConfirmationModal';
 
 const restarauntImageMapping = {
   Subway:
@@ -34,6 +38,12 @@ export default chakra(function ViewOrderModal({
   isOpen,
   onClose,
 }) {
+  const { isOpen: isConfirmationOpen, onOpen: onConfirmationOpen, onClose: onConfirmationClose } = useDisclosure();
+  const dispatch = useDispatch();
+  const deleteOrder = () => {
+    dispatch(removeOrderAsync(data.orderId));
+    onConfirmationClose();
+  }
   return (
     <Modal isOpen={isOpen} onClose={onClose} className={className}>
       <ModalOverlay />
@@ -42,6 +52,12 @@ export default chakra(function ViewOrderModal({
         <ModalCloseButton />
 
         <ModalBody pt="0px">
+          <HStack marginBottom={"10px"}>
+            <Button colorScheme="red" marginRight={"0"} marginLeft={"auto"} onClick={onConfirmationOpen}>
+              Delete Order
+            </Button>
+            <ConfirmationModal isOpen={isConfirmationOpen} onClose={onConfirmationClose} className={className} title={"Confirm delete group order? This cannot be undone"} confirmButton={"CONFIRM"} cancelButton={"CANCEL"} onConfirm={deleteOrder} />
+          </HStack>
           <VStack>
             <Image
               src={restarauntImageMapping[data.restaurant]}

--- a/web/src/components/ViewOrderModal.jsx
+++ b/web/src/components/ViewOrderModal.jsx
@@ -43,6 +43,7 @@ export default chakra(function ViewOrderModal({
   const deleteOrder = () => {
     dispatch(removeOrderAsync(data.orderId));
     onConfirmationClose();
+    onClose();
   }
   return (
     <Modal isOpen={isOpen} onClose={onClose} className={className}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59301359/175543257-0714e901-a0af-4bf0-8b85-0c96092e4f55.png)
![image](https://user-images.githubusercontent.com/59301359/175543295-78e50f1f-8c4b-4efa-83b6-7d4d3604a032.png)

### Description

-  Added a button to delete a group order on the View Order Modal and connected it to the thunk that deletes an order

- This was not in the task description but I decided to make a general confirmation modal that can be reused for any future confirmation popups (it only consists of a heading and a footer with 2 buttons with text that can be customized)

I thought this looked ok but feel free to suggest changes if it's bad UI/UX design!

