### PR TITLE
Order page status

### DIFF
--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -141,7 +141,7 @@ router.post('/add', function (req, res, next) {
   const maxSize = req.body.maxSize;
   const orderId = req.body.orderId;
   const creatorUserId = req.body.creatorUserId;
-  const orderStatus = 'new';
+  const orderStatus = 'open';
   const orderDetails = [];
 
   const newOrder = new Order({

--- a/web/src/pages/GroupOrderPage.jsx
+++ b/web/src/pages/GroupOrderPage.jsx
@@ -33,6 +33,31 @@ const GroupOrderPage = () => {
     })();
   }, []);
 
+  const getStatusMessage = (status) => {
+    if (status === 'open'){
+      return (
+        <Box backgroundColor={'lightgreen'} rounded="5px" paddingLeft={"10px"}>
+          <Heading size={"lg"}>OPEN</Heading>
+          <Text>You can modify this order at this time</Text>
+        </Box>
+      )
+    } else if (status === 'closed') {
+      return (
+        <Box backgroundColor={'red'} rounded="5px" paddingLeft={"10px"}>
+          <Heading size={"lg"}>CLOSED</Heading>
+          <Text>Order in progress, no more changes can be made!</Text>
+        </Box>
+      )
+    } else if (status === 'completed') {
+      return (
+        <Box backgroundColor={'lightblue'} rounded="5px" paddingLeft={"10px"}>
+          <Heading size={"lg"}>COMPLETED</Heading>
+          <Text>Order completed!</Text>
+        </Box>
+      )
+    }
+  };
+
   return (
     <VStack>
       <Header />
@@ -86,7 +111,7 @@ const GroupOrderPage = () => {
                 objectFit="cover"
               />
 
-              <HStack mt="10px" h="60px">
+              <HStack mt="10px">
                 <Heading>{groupOrder.restaurant}</Heading>
                 <HStack
                   border="1px solid gray"
@@ -106,6 +131,9 @@ const GroupOrderPage = () => {
                     <Text fontWeight="semibold">{groupOrder.pickupTime}</Text>
                   </Box>
                 </HStack>
+                <Box flexGrow={1} rounded="5px" h="100%">
+                  {getStatusMessage(groupOrder.orderStatus)}
+                </Box>
               </HStack>
 
               {/* Render all currently added orders as cards */}

--- a/web/src/pages/GroupOrderPage.jsx
+++ b/web/src/pages/GroupOrderPage.jsx
@@ -83,7 +83,7 @@ const GroupOrderPage = () => {
                     Go Back
                   </Button>
                   <Button
-                    disabled={isOrderFull}
+                    disabled={isOrderFull || groupOrder.orderStatus !== 'open'}
                     w="130px"
                     onClick={() => navigate('/menu')}
                   >


### PR DESCRIPTION
Renders a little banner on the top of the order page depending on status of order. The information is from the db in the orderStatus property:

- "open": can modify order i.e. add to order
- "closed": can't modify order since the order is already in progress
- "completed": order is finished

![image](https://user-images.githubusercontent.com/59301359/178095343-7906dc89-3646-40d1-9312-bbec5b093fad.png)
![image](https://user-images.githubusercontent.com/59301359/178095374-2b07ef80-590e-429a-9a57-8becb39b1405.png)
![image](https://user-images.githubusercontent.com/59301359/178095382-f044b631-f19a-4aa6-a7d2-145f114e1b1d.png)

