### PR TITLE
Add Dark mode toggle

### DIFF
--- a/web/src/components/GroupCard/GroupCard.jsx
+++ b/web/src/components/GroupCard/GroupCard.jsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { chakra, Flex } from '@chakra-ui/react';
+import { chakra, Flex, useColorModeValue } from '@chakra-ui/react';
 
 export default chakra(function GroupCard({ className, children }) {
+  const bg = useColorModeValue('gray.50', 'gray.700');
+  const bgHover = useColorModeValue('gray.100', 'gray.500');
   return (
     <Flex
       className={className}
       justify="center"
       w="300px"
       h="244px"
-      bg="gray.50"
+      bg={bg}
       p="7px"
       rounded="10px"
       _hover={{
-        bg: 'gray.100',
+        bg: { bgHover },
         transform: 'scale(1.05)',
         boxShadow: '5px 5px 15px rgba(0,0,0,0.1)',
       }}

--- a/web/src/components/Header/Header.jsx
+++ b/web/src/components/Header/Header.jsx
@@ -1,10 +1,12 @@
 import { Box, HStack, chakra } from '@chakra-ui/react';
+import { useColorModeValue } from '@chakra-ui/react';
 
 import HeaderTray from './HeaderTray';
 const Header = ({ className }) => {
+  const bg = useColorModeValue('gray.100', 'black.200');
   return (
     <Box
-      bgColor="gray.100"
+      bgColor={bg}
       p="7px"
       w="100%"
       position="fixed"

--- a/web/src/components/Header/HeaderTray.jsx
+++ b/web/src/components/Header/HeaderTray.jsx
@@ -29,6 +29,7 @@ import { HamburgerIcon } from '@chakra-ui/icons';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import ToggleColor from '../ToggleColor';
 
 import { signedOutUserObject } from '../../utils/SignedOutUserObject';
 
@@ -90,22 +91,28 @@ const HeaderTray = () => {
             </HStack>
           </a>
         </HStack>
-        <div id="signInDiv"></div>
-        {user.userName !== 'Foodie' ? (
-          <HStack
-            p="10px"
-            onClick={handleSignOut}
-            style={{ cursor: 'pointer' }}
-          >
-            <Icon as={IoMdPower} w={6} h={6} />
-            <Text fontSize="20px">Logout</Text>
-          </HStack>
-        ) : (
-          <HStack p="10px" onClick={handleSignIn} style={{ cursor: 'pointer' }}>
-            <Icon as={IoMdPower} w={6} h={6} />
-            <Text fontSize="20px">Login</Text>
-          </HStack>
-        )}
+        <HStack>
+          <ToggleColor />
+          {user.userName !== 'Foodie' ? (
+            <HStack
+              p="10px"
+              onClick={handleSignOut}
+              style={{ cursor: 'pointer' }}
+            >
+              <Icon as={IoMdPower} w={6} h={6} />
+              <Text fontSize="20px">Logout</Text>
+            </HStack>
+          ) : (
+            <HStack
+              p="10px"
+              onClick={handleSignIn}
+              style={{ cursor: 'pointer' }}
+            >
+              <Icon as={IoMdPower} w={6} h={6} />
+              <Text fontSize="20px">Login</Text>
+            </HStack>
+          )}
+        </HStack>
       </HStack>
       <Drawer placement="left" onClose={onClose} isOpen={isOpen}>
         <DrawerOverlay />

--- a/web/src/components/Header/HeaderTray.jsx
+++ b/web/src/components/Header/HeaderTray.jsx
@@ -92,7 +92,7 @@ const HeaderTray = () => {
           </a>
         </HStack>
         <HStack>
-          <ToggleColor />
+          {/* <ToggleColor /> */}
           {user.userName !== 'Foodie' ? (
             <HStack
               p="10px"

--- a/web/src/components/Order/MemberOrderDetail.jsx
+++ b/web/src/components/Order/MemberOrderDetail.jsx
@@ -1,4 +1,12 @@
-import { chakra, Box, Heading, HStack, Text, Circle } from '@chakra-ui/react';
+import {
+  chakra,
+  Box,
+  Heading,
+  HStack,
+  Text,
+  Circle,
+  useColorModeValue,
+} from '@chakra-ui/react';
 
 const colorMapping = {
   0: 'green.600',
@@ -8,10 +16,12 @@ const colorMapping = {
 };
 
 export default chakra(function MemberOrderDetail({ className, groupOrder }) {
+  const bg = useColorModeValue('gray.200', 'gray.700');
+
   return (
     <HStack className={className} spacing="30px">
       {groupOrder.orderDetails.map((order, i) => (
-        <Box key={i} h="300px" w="200px" bg="gray.200" rounded="20px">
+        <Box key={i} h="300px" w="200px" bg={bg} rounded="20px">
           <Box alignItems="flex-start">
             <Heading
               size="md"

--- a/web/src/components/OrderHistory/GroupOrderManageCard.jsx
+++ b/web/src/components/OrderHistory/GroupOrderManageCard.jsx
@@ -10,6 +10,7 @@ import {
   Button,
   Spacer,
   useDisclosure,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router';
 
@@ -24,6 +25,7 @@ export default chakra(function GroupOrderManageCard({
 }) {
   const nav = useNavigate();
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const bg = useColorModeValue('gray.50', 'gray.700');
 
   const handleViewOrder = () => {
     nav(`/group/${groupOrder._id}`);
@@ -38,7 +40,7 @@ export default chakra(function GroupOrderManageCard({
   };
 
   return (
-    <Flex w="800px" className={className} h="150px" bg="gray.50" rounded="10px">
+    <Flex w="800px" className={className} h="150px" bg={bg} rounded="10px">
       <HStack w="100%">
         <Image
           src={restaurantImageMapping[groupOrder.restaurant]}

--- a/web/src/components/OrderHistory/ManageOrderModal.jsx
+++ b/web/src/components/OrderHistory/ManageOrderModal.jsx
@@ -21,6 +21,7 @@ import {
   MenuItem,
   HStack,
   useDisclosure,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 
@@ -50,6 +51,7 @@ export default chakra(function ManageOrderModal({
   };
 
   const [orderStatus, setOrderStatus] = useState(data.orderStatus);
+  const bg = useColorModeValue('red.100', 'red.700');
 
   const handleSavePUTReq = () => {
     const newOrderStatus = {
@@ -158,7 +160,7 @@ export default chakra(function ManageOrderModal({
                   />
                 ))
               ) : (
-                <Box bg="red.100" rounded="20px" w="100%">
+                <Box bg={bg} rounded="20px" w="100%">
                   <Text textAlign="center" p="10px" fontWeight="600">
                     No Members in Order
                   </Text>

--- a/web/src/components/OrderHistory/OrderDetailUser.jsx
+++ b/web/src/components/OrderHistory/OrderDetailUser.jsx
@@ -5,6 +5,7 @@ import {
   HStack,
   useDisclosure,
   Spacer,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import ConfirmationModal from '../ConfirmationModal';
@@ -19,6 +20,7 @@ export default chakra(function OrderDetailUser({
     onOpen: onConfirmationOpen,
     onClose: onConfirmationClose,
   } = useDisclosure();
+  const bg = useColorModeValue('gray.100', 'gray.700');
 
   const navigate = useNavigate();
 
@@ -41,7 +43,7 @@ export default chakra(function OrderDetailUser({
   };
 
   return (
-    <HStack w="100%" bg="gray.100" p="5px" rounded="10px" className={className}>
+    <HStack w="100%" bg={bg} p="5px" rounded="10px" className={className}>
       <Button
         colorScheme="teal"
         variant="link"

--- a/web/src/components/ToggleColor.jsx
+++ b/web/src/components/ToggleColor.jsx
@@ -1,0 +1,30 @@
+import {
+  FormLabel,
+  Switch,
+  useColorMode,
+  Button,
+  FormControl,
+} from '@chakra-ui/react';
+import { MoonIcon, SunIcon } from '@chakra-ui/icons';
+
+const ToggleColor = () => {
+  const { colorMode, toggleColorMode } = useColorMode();
+  return (
+    <FormControl display="flex" alignItems="center">
+      <FormLabel htmlFor="toggleTheme" mb="0" mr="5px">
+        <SunIcon w={6} h={6} />
+        {/* Light */}
+      </FormLabel>
+      <Switch id="toggleTheme" onChange={toggleColorMode} />
+      <FormLabel htmlFor="toggleTheme" mb="0" ml="5px">
+        <MoonIcon w={6} h={6} />
+        {/* Dark */}
+      </FormLabel>
+    </FormControl>
+    // <Button onClick={toggleColorMode}>
+    //   Toggle {colorMode === 'light' ? 'Dark' : 'Light'}
+    // </Button>
+  );
+};
+
+export default ToggleColor;

--- a/web/src/components/ToggleColor.jsx
+++ b/web/src/components/ToggleColor.jsx
@@ -4,26 +4,50 @@ import {
   useColorMode,
   Button,
   FormControl,
+  Box,
+  Text,
 } from '@chakra-ui/react';
 import { MoonIcon, SunIcon } from '@chakra-ui/icons';
 
+import { useEffect, useState } from 'react';
+
 const ToggleColor = () => {
   const { colorMode, toggleColorMode } = useColorMode();
+  const [toggle, setToggle] = useState(false);
+
+  useEffect(() => {
+    // check when the component is loaded
+    const localStorageToggled = localStorage.getItem('TOGGLE_MODE');
+
+    // If is not null
+    if (localStorageToggled) {
+      setToggle(localStorageToggled === 'true' ? true : false);
+    } else {
+      // If null set the localStorage key/value as a string.
+      localStorage.setItem('TOGGLE_MODE', `${toggle}`);
+    }
+  }, [toggle]);
+
+  const handleToggle = () => {
+    localStorage.setItem('TOGGLE_MODE', `${!toggle}`);
+    setToggle(!toggle);
+    toggleColorMode();
+  };
   return (
-    <FormControl display="flex" alignItems="center">
-      <FormLabel htmlFor="toggleTheme" mb="0" mr="5px">
-        <SunIcon w={6} h={6} />
-        {/* Light */}
-      </FormLabel>
-      <Switch id="toggleTheme" onChange={toggleColorMode} />
-      <FormLabel htmlFor="toggleTheme" mb="0" ml="5px">
-        <MoonIcon w={6} h={6} />
-        {/* Dark */}
-      </FormLabel>
-    </FormControl>
-    // <Button onClick={toggleColorMode}>
-    //   Toggle {colorMode === 'light' ? 'Dark' : 'Light'}
-    // </Button>
+    <Box>
+      <Text fontSize="lg">Change Theme:</Text>
+      <FormControl display="flex" alignItems="center">
+        <FormLabel htmlFor="toggleTheme" mb="0" mr="5px">
+          <SunIcon w={6} h={6} />
+          {/* Light */}
+        </FormLabel>
+        <Switch id="toggleTheme" isChecked={toggle} onChange={handleToggle} />
+        <FormLabel htmlFor="toggleTheme" mb="0" ml="5px">
+          <MoonIcon w={6} h={6} />
+          {/* Dark */}
+        </FormLabel>
+      </FormControl>
+    </Box>
   );
 };
 

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -3,6 +3,8 @@ import * as ReactDOM from 'react-dom/client';
 import App from './App';
 import { Provider } from 'react-redux';
 import { store } from './redux/store';
+import { ColorModeScript } from '@chakra-ui/react';
+import theme from './theme';
 
 const container = document.getElementById('root');
 const root = ReactDOM.createRoot(container);
@@ -10,6 +12,7 @@ const root = ReactDOM.createRoot(container);
 root.render(
   <StrictMode>
     <Provider store={store}>
+      <ColorModeScript initialColorMode={theme.config.initialColorMode} />
       <App />
     </Provider>
   </StrictMode>

--- a/web/src/pages/AboutPage.jsx
+++ b/web/src/pages/AboutPage.jsx
@@ -23,6 +23,7 @@ import {
   AccordionButton,
   AccordionPanel,
   AccordionIcon,
+  useColorModeValue,
 } from '@chakra-ui/react';
 
 const faqArray = [
@@ -54,14 +55,16 @@ const faqArray = [
 ];
 
 const Home = () => {
+  const bg = useColorModeValue('gray.300', 'gray.700');
+
   return (
     <div>
       <Header />
       <Box
-        marginTop="3%"
+        marginTop="4%"
         align="center"
         p="30px"
-        bg="gray.300"
+        bg={bg}
         // w={{ lg: '600px', md: '600px', base: '100%' }}
         w="100%"
         h="400px"
@@ -147,7 +150,7 @@ const Home = () => {
         w="100%"
         h="100%"
         borderRadius="10px"
-        bg="gray.100"
+        bg={bg}
       >
         <Heading size="2xl" mt="25px" textAlign="center">
           Frequently Asked Questions

--- a/web/src/pages/AccountPage.jsx
+++ b/web/src/pages/AccountPage.jsx
@@ -14,8 +14,10 @@ import {
   FormControl,
   FormLabel,
   Input,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import { useState, useEffect } from 'react';
+import ToggleColor from '../components/ToggleColor';
 
 import { useSelector, useDispatch } from 'react-redux';
 import { removeUserAsync } from '../redux/users/thunk';
@@ -27,6 +29,7 @@ const AccountsPage = () => {
   const dispatch = useDispatch();
   const nav = useNavigate();
   const toast = useToast();
+  const bg = useColorModeValue('gray.100', 'gray.700');
 
   const [user, setUser] = useState(() => {
     // getting stored value from localStorage
@@ -60,7 +63,7 @@ const AccountsPage = () => {
               marginTop="6%"
               align="left"
               p="35px"
-              bg="gray.300"
+              bg={bg}
               // w={{ lg: '600px', md: '600px', base: '100%' }}
               w="100%"
               h="100px"
@@ -71,7 +74,7 @@ const AccountsPage = () => {
             <Box
               align="left"
               p="35px"
-              bg="gray.100"
+              bg={bg}
               // w={{ lg: '600px', md: '600px', base: '100%' }}
               w="100%"
               h="100%"
@@ -94,7 +97,6 @@ const AccountsPage = () => {
                   defaultValue={user.userEmail}
                 />
               </FormControl>
-
               {user.userName !== 'Foodie' && (
                 <Box align="right" w="100%" pt="20px">
                   <Button
@@ -113,7 +115,8 @@ const AccountsPage = () => {
                     Delete Account
                   </Button>
                 </Box>
-              )}
+              )}{' '}
+              <ToggleColor />
             </Box>
           </>
         ) : (

--- a/web/src/pages/ProfilePage.jsx
+++ b/web/src/pages/ProfilePage.jsx
@@ -14,6 +14,7 @@ import {
   Button,
   useToast,
   useClipboard,
+  useColorModeValue,
 } from '@chakra-ui/react';
 
 import { useEffect } from 'react';
@@ -95,6 +96,8 @@ const ProfilePage = () => {
 
   const { hasCopied, onCopy } = useClipboard(window.location.href);
   const toast = useToast();
+  const bg = useColorModeValue('gray.300', 'black.200');
+  const bg2 = useColorModeValue('blue.100', 'gray.500');
 
   useEffect(() => {
     (async () => {
@@ -114,10 +117,10 @@ const ProfilePage = () => {
       {Object.keys(user).length > 1 ? (
         <>
           <Box
-            marginTop="6%"
+            marginTop="4%"
             align="center"
             p="30px"
-            bg="gray.300"
+            bg={bg}
             // w={{ lg: '600px', md: '600px', base: '100%' }}
             w="100%"
             h="400px"
@@ -171,7 +174,7 @@ const ProfilePage = () => {
           <Box
             align="center"
             p="30px"
-            bg="gray.200"
+            bg={bg}
             // w={{ lg: '600px', md: '600px', base: '100%' }}
             w="100%"
             h="100%"
@@ -186,7 +189,7 @@ const ProfilePage = () => {
               return (
                 <Box
                   key={index}
-                  backgroundColor="blue.100"
+                  backgroundColor={bg2}
                   padding="20px"
                   margin="10px"
                 >

--- a/web/src/theme.js
+++ b/web/src/theme.js
@@ -1,5 +1,12 @@
 import { extendTheme } from '@chakra-ui/react';
-const theme = extendTheme({
-  components: {},
-});
+
+// 2. Add your color mode config
+const config = {
+  initialColorMode: 'light',
+  useSystemColorMode: false,
+};
+
+// 3. extend the theme
+const theme = extendTheme({ config });
+
 export default theme;


### PR DESCRIPTION
Attention!
Be sure to add the dark mode to new pages and components going forward!

Steps Example:,
```import { Box, HStack, chakra } from '@chakra-ui/react';
import { useColorModeValue } from '@chakra-ui/react';

import HeaderTray from './HeaderTray';
const Header = ({ className }) => {
  const bg = useColorModeValue('gray.100', 'black.200');
  return (
    <Box
      bgColor={bg}
      p="7px"
      w="100%"
      position="fixed"
      top="0px"
      overflow="hidden"
      className={className}
      marginBottom="10px"
      zIndex="3"
      borderStyle="solid"
      borderWidth="1px"
    >
      <HeaderTray />
    </Box>
  );
};
```

How toggle works right now!
1. Go to http://localhost:3000/account
2. Click on the switch
3. Toggle between light or dark mode.
4. After toggling, it stores the switch state in localStorage
5. useEffect will read the state everytime you visit this page.
6. apply toggled mode globally.


Example:
![image](https://user-images.githubusercontent.com/10675973/178972080-92fc3a5b-9fa4-4926-84ab-fd92984e8783.png)
![image](https://user-images.githubusercontent.com/10675973/178972117-51786001-d9d6-44d0-ba3b-7e5837b82b0e.png)
![image](https://user-images.githubusercontent.com/10675973/178972017-28ed5706-8dfc-4330-9954-54db8407838a.png)
