### PR TITLE
fix null localstorage errors

### DIFF
--- a/src/components/GroupCard/GroupOrderNew.jsx
+++ b/src/components/GroupCard/GroupOrderNew.jsx
@@ -17,7 +17,7 @@ import CreateGroupForm from '../CreateGroupForm';
 
 export default chakra(function GroupOrderNew({ className }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const user = JSON.parse(localStorage.getItem('userSession_FriendDash'));
+  const user = localStorage.getItem('userSession_FriendDash');
 
   return (
     <Box>
@@ -30,7 +30,7 @@ export default chakra(function GroupOrderNew({ className }) {
 
             <Box h="10px" />
 
-            <Button colorScheme="teal" w="50px" h="50px" rounded="25px" disabled={user.userName === "Foodie"} >
+            <Button colorScheme="teal" w="50px" h="50px" rounded="25px" disabled={!user || JSON.parse(user).userName === "Foodie"} >
               <AddIcon w={6} h={6} onClick={onOpen} />
             </Button>
 

--- a/src/components/ViewOrderModal.jsx
+++ b/src/components/ViewOrderModal.jsx
@@ -30,7 +30,7 @@ export default chakra(function ViewOrderModal({
   onClose,
 }) {
   const navigate = useNavigate();
-  const user = JSON.parse(localStorage.getItem('userSession_FriendDash'));
+  const user = localStorage.getItem('userSession_FriendDash');
   return (
     <Modal isOpen={isOpen} onClose={onClose} className={className}>
       <ModalOverlay />
@@ -81,7 +81,7 @@ export default chakra(function ViewOrderModal({
           <Button
             colorScheme="teal"
             w="110px"
-            disabled={user.userName === "Foodie"}
+            disabled={!user || JSON.parse(user).userName === "Foodie"}
             onClick={() => navigate(`/group/${data._id}`)}
           >
             Join Order


### PR DESCRIPTION
Users who don't have Foodie cached will run into an error because dashboard will try to access a property of the user object in localstorage. Check whether the item is null before trying to access it (to disable buttons for users not logged in)